### PR TITLE
Added loaded, compatible and version check

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -1,5 +1,7 @@
 " Prevent multi loads and disable in compatible mode
-if exists('g:loaded_numbertoggle') || &cp
+" check if vim version is at least 7.3 
+" (relativenumber is not supported below)
+if exists('g:loaded_numbertoggle') || &cp || v:version < 703
   finish
 endif
 let g:loaded_numbertoggle = 1


### PR DESCRIPTION
Hey,

i just read your post about vim's relativenumber option. (Did not know that one, thanks!)
I downloaded your plugin and added a few lines:
- a check to see if the plugin as already been loaded
- do not load if in compatible mode
- do not load if vim version is below 7.3 as relativenumber is not available below

maybe you want to have a look!

best regards
