### PR TITLE
Avoid changing actual width of the number column with each jump between number and relativenumber

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -29,8 +29,6 @@ function! UpdateMode()
 	" number and relativenumber:
 	let &numberwidth = max([4, 1+len(line('$'))])
 	" Explanation of the calculation:
-	" - Add 1 to the number of lines before the ceil+log to wrap over correctly
-	"   999->3, 1000->4, 9999->4, 10000->5, ...
 	" - Add 1 to the calculated maximal width to make room for the space
 	" - Assume 4 as the minimum desired width.
 endfunc


### PR DESCRIPTION
This is a feature request with a quick demonstration of what I'd like, but it's probably inefficient.

The feature is relevant for files of 1000 lines or more (unless you changed your numberwidth from the default of 4, in which case you'd probably know why it's relevant anyway).

(TBH, this feature should probably be in vim proper)
