### PR TITLE
Toggle line numbers correctly when switching windows

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -64,6 +64,8 @@ autocmd FileReadPost * :call UpdateMode()
 " when the focus is regained.
 autocmd FocusLost * :call FocusLost()
 autocmd FocusGained * :call FocusGained()
+autocmd WinLeave * :call FocusLost()
+autocmd WinEnter * :call FocusGained()
 
 " Switch to absolute line numbers when entering insert mode and switch back to
 " relative line numbers when switching back to normal mode.


### PR DESCRIPTION
When a window is no longer active, we want to use absolute instead
of relative line numbering...

Signed-off-by: Greg Dietsche Gregory.Dietsche@cuw.edu
