### PR TITLE
Remove the default key binding for toggling the numbers

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -74,6 +74,4 @@ autocmd InsertLeave * :call InsertLeave()
 
 if exists('g:NumberToggleTrigger')
 	exec "nnoremap <silent> " . g:NumberToggleTrigger . " :call NumberToggle()<cr>"
-else
-	nnoremap <silent> <C-n> :call NumberToggle()<cr>
 endif


### PR DESCRIPTION
Please consider removing the default key binding. I don't use this feature and only messes up my existing key binding for C-n. Since it's still configurable, everybody who wants to have this key binding can still enable it.
