### PR TITLE
Honor user setting of numberwidth

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -18,15 +18,13 @@ function! NumberToggle()
 endfunc
 
 function! UpdateMode()
-	if buflisted(bufnr("%"))
-		if(g:focus == 0)
-			set number
-		elseif(g:insertmode == 0)
-			set relativenumber
-		else
-			set number
-		end
-	endif
+	if(g:focus == 0)
+		set number
+	elseif(g:insertmode == 0)
+		set relativenumber
+	else
+		set number
+	end
 	
 	if !exists("&numberwidth") || &numberwidth <= 4
 		" Avoid changing actual width of the number column with each jump between


### PR DESCRIPTION
Only force numberwidth=4 if &numberwidth does not exist at all or is
set to a value smaller than 4
