### PR TITLE
Track line number state through inserts

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -7,20 +7,23 @@ endif
 let g:loaded_numbertoggle = 1
 let g:insertmode = 0
 let g:focus = 1
+let g:relativemode = 1
 
 " NumberToggle toggles between relative and absolute line numbers
 function! NumberToggle()
 	if(&relativenumber == 1)
 		set number
+        let g:relativemode = 0
 	else
 		set relativenumber
+        let g:relativemode = 1
 	endif
 endfunc
 
 function! UpdateMode()
 	if(g:focus == 0)
 		set number
-	elseif(g:insertmode == 0)
+	elseif(g:insertmode == 0 && g:relativemode == 1)
 		set relativenumber
 	else
 		set number


### PR DESCRIPTION
If you change the numbering from relative to absolute and then enter and
exit insert mode, the numbering will revert to relative. This will
track the current state and return to that after leaving insert mode.
