### PR TITLE
Support vim's ability to use number and/or relativenumber

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -8,14 +8,24 @@ let g:loaded_numbertoggle = 1
 let g:insertmode = 0
 let g:focus = 1
 let g:relativemode = 1
+" set to 1 to only toggle relativenumber (allowing to use it with number); Else
+" number will also be toggled when needed, so it's either relativenumber or
+" number, but never both at the same time
+let g:only_toggle_relativenumber = 1
 
 " NumberToggle toggles between relative and absolute line numbers
 function! NumberToggle()
 	if(&relativenumber == 1)
-		set number
+		set norelativenumber
+		if(g:only_toggle_relativenumber == 0)
+			set number
+		endif
 		let g:relativemode = 0
 	else
 		set relativenumber
+		if(g:only_toggle_relativenumber == 0)
+			set nonumber
+		endif
 		let g:relativemode = 1
 	endif
 endfunc
@@ -26,11 +36,20 @@ function! UpdateMode()
 	end
 
 	if(g:focus == 0)
-		set number
+		set norelativenumber
+		if(g:only_toggle_relativenumber == 0)
+			set number
+		endif
 	elseif(g:insertmode == 0 && g:relativemode == 1)
 		set relativenumber
+		if(g:only_toggle_relativenumber == 0)
+			set nonumber
+		endif
 	else
-		set number
+		set norelativenumber
+		if(g:only_toggle_relativenumber == 0)
+			set number
+		endif
 	end
 	
 	if !exists("&numberwidth") || &numberwidth <= 4

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -1,5 +1,5 @@
 " Prevent multi loads and disable in compatible mode
-" check if vim version is at least 7.3 
+" check if vim version is at least 7.3
 " (relativenumber is not supported below)
 if exists('g:loaded_numbertoggle') || &cp || v:version < 703
 	finish
@@ -13,10 +13,10 @@ let g:relativemode = 1
 function! NumberToggle()
 	if(&relativenumber == 1)
 		set number
-        let g:relativemode = 0
+		let g:relativemode = 0
 	else
 		set relativenumber
-        let g:relativemode = 1
+		let g:relativemode = 1
 	endif
 endfunc
 


### PR DESCRIPTION
Apparently not everyone likes to have the current line number shown when using relativenumber, so vim now offers the choice. To handle this for hopefully everyone, this adds g:only_toggle_relativenumber

When enabled (the default), only relativenumber is toggled (thus obviously assuming number is on); Else number will also be toggled as needed, to never have both options at the same time.
