### PR TITLE
New functionality plus some code reorganization and cleanup

### DIFF
--- a/doc/numbertoggle.txt
+++ b/doc/numbertoggle.txt
@@ -15,9 +15,18 @@ TRIGGER                                         *numbertoggle-trigger*
 In case g:UseNumberToggleTrigger is unset or true, NumberToggle sets
 up <C-n> to toggle from absolute to relative line numbers.
 You can set up another trigger if you prefer. If you want to
-toggle using <F2>, for example, put this into your ~/.vimrc file:
+toggle using <F3>, for example, put this into your ~/.vimrc file:
 
-    nmap <silent> <F2> <Plug>NumberToggleTrigger
+    nmap <silent> <F3> <Plug>NumberToggleTrigger
+
+SHOW/HIDE ALL NUMBERS                        *numbertoggle-showhide*
+
+If you want a convenient way to show or hide *all* numbers in the buffer, you
+can map a key to `<Plug>NumberToggleShowHideAll`. This is not mapped by
+default, but to map this functionality to, for example, '<Leader><F3>', add the
+following to your ~/.vimrc file:
+
+    nmap <silent> <Leader><F2> <Plug>NumberToggleShowHideAll
 
 ABOUT                                           *numbertoggle-about*
 

--- a/doc/numbertoggle.txt
+++ b/doc/numbertoggle.txt
@@ -26,7 +26,7 @@ can map a key to `<Plug>NumberToggleShowHideAll`. This is not mapped by
 default, but to map this functionality to, for example, '<Leader><F3>', add the
 following to your ~/.vimrc file:
 
-    nmap <silent> <Leader><F2> <Plug>NumberToggleShowHideAll
+    nmap <silent> <Leader><F3> <Plug>NumberToggleShowHideAll
 
 ABOUT                                           *numbertoggle-about*
 

--- a/doc/numbertoggle.txt
+++ b/doc/numbertoggle.txt
@@ -1,6 +1,7 @@
 *numbertoggle.txt*	(auto-)toggeling for Vim line numbers
 
 Author:  Jeff Kreeftmeijer <http://jeffkreeftmeijer.com>
+Modified by: Jeet Sukumaran <http://jeetworks.org>
 
 INTRODUCTION                                    *numbertoggle*
 
@@ -16,7 +17,7 @@ up <C-n> to toggle from absolute to relative line numbers.
 You can set up another trigger if you prefer. If you want to
 toggle using <F2>, for example, put this into your ~/.vimrc file:
 
-  let g:NumberToggleTrigger="<F2>"
+    nmap <silent> <F2> <Plug>NumberToggleTrigger
 
 ABOUT                                           *numbertoggle-about*
 

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -39,6 +39,19 @@ function! s:NumberToggle()
     endif
 endfunc
 
+" Completely hides all numbers if showing;
+" shows them again if not showing
+function! s:NumberToggleShowHideAll()
+    if &relativenumber || &number
+        set nonumber
+        set norelativenumber
+    else
+        set number
+        set relativenumber
+        call s:UpdateMode()
+    endif
+endfunc
+
 function! s:UpdateMode()
     if &number == 0 && &relativenumber == 0
         return
@@ -120,6 +133,7 @@ endif
 
 " Plugin Key mapping to toggle NumberToggle
 nnoremap <silent> <Plug>NumberToggleTrigger :call <SID>NumberToggle()<CR>
+nnoremap <silent> <Plug>NumberToggleShowHideAll :call <SID>NumberToggleShowHideAll()<CR>
 
 " Define key mapping
 if exists('g:NumberToggleTrigger')

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -11,6 +11,9 @@ endif
 if !exists("g:numbertoggle_enable_relativenumber_in_insert_mode")
     let g:numbertoggle_enable_relativenumber_in_insert_mode = 0
 endif
+if !exists("g:numbertoggle_ignore_filetypes")
+    let g:numbertoggle_ignore_filetypes = ["filebeagle"]
+endif
 let s:insert_mode = 0
 let s:focus = 1
 let s:relativenumber_mode = 1
@@ -56,10 +59,12 @@ function! s:NumberToggleShowHideAll()
 endfunc
 
 function! s:UpdateMode()
+    if index(g:numbertoggle_ignore_filetypes, &ft) != -1
+        return
+    endif
     if &number == 0 && &relativenumber == 0
         return
     end
-
     if s:focus == 0
         call s:DisableRelativeNumbers()
     elseif s:insert_mode == 0 && s:relativenumber_mode == 1

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -28,11 +28,6 @@ function! s:DisableRelativeNumbers()
     set norelativenumber
 endfunc
 
-function! s:DisableAllNumbers()
-    set nonumber
-    set norelativenumber
-endfunction
-
 " NumberToggle toggles between relative and absolute line numbers
 function! s:NumberToggle()
     if &relativenumber == 1
@@ -90,29 +85,33 @@ function! s:InsertEnter()
     call s:UpdateMode()
 endfunc
 
+if has("autocmd")
+    augroup NumberToggle
+        autocmd!
+        " Automatically set relative line numbers when opening a new document
+        autocmd BufNewFile * :call <SID>UpdateMode()
+        autocmd BufReadPost * :call <SID>UpdateMode()
+        autocmd FilterReadPost * :call <SID>UpdateMode()
+        autocmd FileReadPost * :call <SID>UpdateMode()
 
-" Automatically set relative line numbers when opening a new document
-autocmd BufNewFile * :call <SID>UpdateMode()
-autocmd BufReadPost * :call <SID>UpdateMode()
-autocmd FilterReadPost * :call <SID>UpdateMode()
-autocmd FileReadPost * :call <SID>UpdateMode()
+        " Automatically switch to absolute numbers when focus is lost and switch back
+        " when the focus is regained.
+        autocmd FocusLost * :call <SID>FocusLost()
+        autocmd FocusGained * :call <SID>FocusGained()
+        autocmd WinLeave * :call <SID>FocusLost()
+        autocmd WinEnter * :call <SID>FocusGained()
 
-" Automatically switch to absolute numbers when focus is lost and switch back
-" when the focus is regained.
-autocmd FocusLost * :call <SID>FocusLost()
-autocmd FocusGained * :call <SID>FocusGained()
-autocmd WinLeave * :call <SID>FocusLost()
-autocmd WinEnter * :call <SID>FocusGained()
+        " Switch to absolute line numbers when the window loses focus and switch back
+        " to relative line numbers when the focus is regained.
+        autocmd WinLeave * :call <SID>FocusLost()
+        autocmd WinEnter * :call <SID>FocusGained()
 
-" Switch to absolute line numbers when the window loses focus and switch back
-" to relative line numbers when the focus is regained.
-autocmd WinLeave * :call <SID>FocusLost()
-autocmd WinEnter * :call <SID>FocusGained()
-
-" Switch to absolute line numbers when entering insert mode and switch back to
-" relative line numbers when switching back to normal mode.
-autocmd InsertEnter * :call <SID>InsertEnter()
-autocmd InsertLeave * :call <SID>InsertLeave()
+        " Switch to absolute line numbers when entering insert mode and switch back to
+        " relative line numbers when switching back to normal mode.
+        autocmd InsertEnter * :call <SID>InsertEnter()
+        autocmd InsertLeave * :call <SID>InsertLeave()
+    augroup end
+endif
 
 " ensures default behavior / backward compatibility
 if ! exists ( 'g:UseNumberToggleTrigger' )

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -11,6 +11,7 @@ let s:relativemode = 1
 
 " Enables relative numbers.
 function! s:EnableRelativeNumbers()
+    " set nonumber
     set nonumber
     set relativenumber
 endfunc

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -5,14 +5,20 @@ if exists('g:loaded_numbertoggle') || &cp || v:version < 703
     finish
 endif
 let g:loaded_numbertoggle = 1
+if !exists("g:numbertoggle_show_current_line_number_in_relativemode")
+    let g:numbertoggle_show_current_line_number_in_relativemode = 1
+endif
 let s:insertmode = 0
 let s:focus = 1
 let s:relativemode = 1
 
 " Enables relative numbers.
 function! s:EnableRelativeNumbers()
-    " set nonumber
-    set nonumber
+    if !g:numbertoggle_show_current_line_number_in_relativemode
+        set nonumber
+    else
+        set number
+    endif
     set relativenumber
 endfunc
 
@@ -22,9 +28,14 @@ function! s:DisableRelativeNumbers()
     set norelativenumber
 endfunc
 
+function! s:DisableAllNumbers()
+    set nonumber
+    set norelativenumber
+endfunction
+
 " NumberToggle toggles between relative and absolute line numbers
 function! s:NumberToggle()
-    if(&relativenumber == 1)
+    if &relativenumber == 1
         call s:DisableRelativeNumbers()
         let s:relativemode = 0
     else
@@ -34,13 +45,13 @@ function! s:NumberToggle()
 endfunc
 
 function! s:UpdateMode()
-    if(&number == 0 && &relativenumber == 0)
+    if &number == 0 && &relativenumber == 0
         return
     end
 
-    if(s:focus == 0)
+    if s:focus == 0
         call s:DisableRelativeNumbers()
-    elseif(s:insertmode == 0 && s:relativemode == 1)
+    elseif s:insertmode == 0 && s:relativemode == 1
         call s:EnableRelativeNumbers()
     else
         call s:DisableRelativeNumbers()
@@ -108,8 +119,12 @@ if ! exists ( 'g:UseNumberToggleTrigger' )
     let g:UseNumberToggleTrigger = 1
 endif
 
+" Plugin Key mapping to toggle NumberToggle
+nnoremap <silent> <Plug>NumberToggleTrigger :call <SID>NumberToggle()<CR>
+
+" Define key mapping
 if exists('g:NumberToggleTrigger')
-    exec "nnoremap <silent> " . g:NumberToggleTrigger . " :call <SID>NumberToggle()<cr>"
-elseif g:UseNumberToggleTrigger
-    nnoremap <silent> <C-n> :call <SID>NumberToggle()<cr>
+    execute "nmap <silent> " . g:NumberToggleTrigger  . " <Plug>NumberToggleTrigger"
+elseif g:UseNumberToggleTrigger && !hasmapto("<Plug>NumberToggleTrigger")
+    nmap <silent> <C-n> <Plug>NumberToggleTrigger
 endif

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -5,16 +5,19 @@ if exists('g:loaded_numbertoggle') || &cp || v:version < 703
     finish
 endif
 let g:loaded_numbertoggle = 1
-if !exists("g:numbertoggle_show_current_line_number_in_relativemode")
-    let g:numbertoggle_show_current_line_number_in_relativemode = 1
+if !exists("g:numbertoggle_show_current_line_number_in_relativenumber_mode")
+    let g:numbertoggle_show_current_line_number_in_relativenumber_mode = 1
 endif
-let s:insertmode = 0
+if !exists("g:numbertoggle_enable_relativenumber_in_insert_mode")
+    let g:numbertoggle_enable_relativenumber_in_insert_mode = 0
+endif
+let s:insert_mode = 0
 let s:focus = 1
-let s:relativemode = 1
+let s:relativenumber_mode = 1
 
 " Enables relative numbers.
 function! s:EnableRelativeNumbers()
-    if !g:numbertoggle_show_current_line_number_in_relativemode
+    if !g:numbertoggle_show_current_line_number_in_relativenumber_mode
         set nonumber
     else
         set number
@@ -32,10 +35,10 @@ endfunc
 function! s:NumberToggle()
     if &relativenumber == 1
         call s:DisableRelativeNumbers()
-        let s:relativemode = 0
+        let s:relativenumber_mode = 0
     else
         call s:EnableRelativeNumbers()
-        let s:relativemode = 1
+        let s:relativenumber_mode = 1
     endif
 endfunc
 
@@ -59,7 +62,9 @@ function! s:UpdateMode()
 
     if s:focus == 0
         call s:DisableRelativeNumbers()
-    elseif s:insertmode == 0 && s:relativemode == 1
+    elseif s:insert_mode == 0 && s:relativenumber_mode == 1
+        call s:EnableRelativeNumbers()
+    elseif s:insert_mode == 1  && g:numbertoggle_enable_relativenumber_in_insert_mode
         call s:EnableRelativeNumbers()
     else
         call s:DisableRelativeNumbers()
@@ -89,12 +94,12 @@ function! s:FocusLost()
 endfunc
 
 function! s:InsertLeave()
-    let s:insertmode = 0
+    let s:insert_mode = 0
     call s:UpdateMode()
 endfunc
 
 function! s:InsertEnter()
-    let s:insertmode = 1
+    let s:insert_mode = 1
     call s:UpdateMode()
 endfunc
 

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -2,113 +2,113 @@
 " check if vim version is at least 7.3
 " (relativenumber is not supported below)
 if exists('g:loaded_numbertoggle') || &cp || v:version < 703
-	finish
+    finish
 endif
 let g:loaded_numbertoggle = 1
-let g:insertmode = 0
-let g:focus = 1
-let g:relativemode = 1
+let s:insertmode = 0
+let s:focus = 1
+let s:relativemode = 1
 
 " Enables relative numbers.
-function! EnableRelativeNumbers()
-  set nonumber
-  set relativenumber
+function! s:EnableRelativeNumbers()
+    set nonumber
+    set relativenumber
 endfunc
 
 " Disables relative numbers.
-function! DisableRelativeNumbers()
-  set number
-  set norelativenumber
+function! s:DisableRelativeNumbers()
+    set number
+    set norelativenumber
 endfunc
 
 " NumberToggle toggles between relative and absolute line numbers
-function! NumberToggle()
-	if(&relativenumber == 1)
-    call DisableRelativeNumbers()
-    let g:relativemode = 0
-	else
-    call EnableRelativeNumbers()
-    let g:relativemode = 1
-	endif
+function! s:NumberToggle()
+    if(&relativenumber == 1)
+        call s:DisableRelativeNumbers()
+        let s:relativemode = 0
+    else
+        call s:EnableRelativeNumbers()
+        let s:relativemode = 1
+    endif
 endfunc
 
-function! UpdateMode()
-	if(&number == 0 && &relativenumber == 0)
-		return
-	end
+function! s:UpdateMode()
+    if(&number == 0 && &relativenumber == 0)
+        return
+    end
 
-	if(g:focus == 0)
-		call DisableRelativeNumbers()
-	elseif(g:insertmode == 0 && g:relativemode == 1)
-		call EnableRelativeNumbers()
-	else
-		call DisableRelativeNumbers()
-	end
+    if(s:focus == 0)
+        call s:DisableRelativeNumbers()
+    elseif(s:insertmode == 0 && s:relativemode == 1)
+        call s:EnableRelativeNumbers()
+    else
+        call s:DisableRelativeNumbers()
+    end
 
-	if !exists("&numberwidth") || &numberwidth <= 4
-		" Avoid changing actual width of the number column with each jump between
-		" number and relativenumber:
-		let &numberwidth = max([4, 1+len(line('$'))])
-	else
-		" Explanation of the calculation:
-		" - Add 1 to the calculated maximal width to make room for the space
-		" - Assume 4 as the minimum desired width if &numberwidth is not set or is
-		"   smaller than 4
-		let &numberwidth = max([&numberwidth, 1+len(line('$'))])
-	endif
+    if !exists("&numberwidth") || &numberwidth <= 4
+        " Avoid changing actual width of the number column with each jump between
+        " number and relativenumber:
+        let &numberwidth = max([4, 1+len(line('$'))])
+    else
+        " Explanation of the calculation:
+        " - Add 1 to the calculated maximal width to make room for the space
+        " - Assume 4 as the minimum desired width if &numberwidth is not set or is
+        "   smaller than 4
+        let &numberwidth = max([&numberwidth, 1+len(line('$'))])
+    endif
 endfunc
 
-function! FocusGained()
-	let g:focus = 1
-	call UpdateMode()
+function! s:FocusGained()
+    let s:focus = 1
+    call s:UpdateMode()
 endfunc
 
-function! FocusLost()
-	let g:focus = 0
-	call UpdateMode()
+function! s:FocusLost()
+    let s:focus = 0
+    call s:UpdateMode()
 endfunc
 
-function! InsertLeave()
-	let g:insertmode = 0
-	call UpdateMode()
+function! s:InsertLeave()
+    let s:insertmode = 0
+    call s:UpdateMode()
 endfunc
 
-function! InsertEnter()
-	let g:insertmode = 1
-	call UpdateMode()
+function! s:InsertEnter()
+    let s:insertmode = 1
+    call s:UpdateMode()
 endfunc
 
 
 " Automatically set relative line numbers when opening a new document
-autocmd BufNewFile * :call UpdateMode()
-autocmd BufReadPost * :call UpdateMode()
-autocmd FilterReadPost * :call UpdateMode()
-autocmd FileReadPost * :call UpdateMode()
+autocmd BufNewFile * :call <SID>UpdateMode()
+autocmd BufReadPost * :call <SID>UpdateMode()
+autocmd FilterReadPost * :call <SID>UpdateMode()
+autocmd FileReadPost * :call <SID>UpdateMode()
 
 " Automatically switch to absolute numbers when focus is lost and switch back
 " when the focus is regained.
-autocmd FocusLost * :call FocusLost()
-autocmd FocusGained * :call FocusGained()
-autocmd WinLeave * :call FocusLost()
-autocmd WinEnter * :call FocusGained()
+autocmd FocusLost * :call <SID>FocusLost()
+autocmd FocusGained * :call <SID>FocusGained()
+autocmd WinLeave * :call <SID>FocusLost()
+autocmd WinEnter * :call <SID>FocusGained()
 
 " Switch to absolute line numbers when the window loses focus and switch back
 " to relative line numbers when the focus is regained.
-autocmd WinLeave * :call FocusLost()
-autocmd WinEnter * :call FocusGained()
+autocmd WinLeave * :call <SID>FocusLost()
+autocmd WinEnter * :call <SID>FocusGained()
 
 " Switch to absolute line numbers when entering insert mode and switch back to
 " relative line numbers when switching back to normal mode.
-autocmd InsertEnter * :call InsertEnter()
-autocmd InsertLeave * :call InsertLeave()
+autocmd InsertEnter * :call <SID>InsertEnter()
+autocmd InsertLeave * :call <SID>InsertLeave()
 
 " ensures default behavior / backward compatibility
 if ! exists ( 'g:UseNumberToggleTrigger' )
-	let g:UseNumberToggleTrigger = 1
+    let g:UseNumberToggleTrigger = 1
 endif
 
 if exists('g:NumberToggleTrigger')
-	exec "nnoremap <silent> " . g:NumberToggleTrigger . " :call NumberToggle()<cr>"
+    exec "nnoremap <silent> " . g:NumberToggleTrigger . " :call <SID>NumberToggle()<cr>"
 elseif g:UseNumberToggleTrigger
-	nnoremap <silent> <C-n> :call NumberToggle()<cr>
+    nnoremap <silent> <C-n> :call <SID>NumberToggle()<cr>
 endif


### PR DESCRIPTION
## New Functionality/Behavior
- (Optionally) allow for current line number to be shown in relative number mode. If this is not desired, then user can set '`g:numbertoggle_show_current_line_number_in_relativemode = 0`'
- Function to show/hide _all_ numbers, regardless of mode (not bound to any key by default, but can easily be bound by, e.g. "`nmap <silent> <Leader><F3> <Plug>NumberToggleShowHideAll`"
- Documentation update to reflect this changes
- (54e51ae) For some, it is confusing to have numbers change on them as they leave insert mode. For these folks, added the option to not toggle between relative and absolute numbers when going between normal and insert modes in the active window. Default behavior remains the same as before.
## Code Reorganization/Cleanup
- Localized all functions to script namespace
- Localized many variables that need not be in global namespace to script namespace
- Use `<Plugin>` architecture for flexible and robust specification of key bindings
- `autocmd`'s placed in isolated/protected block
