### PR TITLE
vim 7.4 support

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -12,7 +12,7 @@ let g:relativemode = 1
 
 " Enables relative numbers.
 function! EnableRelativeNumbers()
-  set number
+  set nonumber
   set relativenumber
 endfunc
 


### PR DESCRIPTION
I noticed upon upgrading my vim to 7.4, you can have both number and relativenumber enabled at the same time, which results in my display looking like this:

![screen shot 2016-10-26 at 1 22 54 pm](https://cloud.githubusercontent.com/assets/3250676/19736914/56f69830-9b7f-11e6-98c1-04925f8e4b74.png)

so in this PR, I've simply changed the EnableRelativeNumbers function to 
```
set nonumber
set relativenumber
```

Maybe there was a typo in this function initially, because it used to have 
```
set number
set relativenumber
```

If the behavior shown in my screenshot is desired, then please disregard this PR - but I thought it was a little bit jarring. Maybe there could be a config option added that enables the user to choose whether they want mixed numbering or not when viewing relative numbers.