### PR TITLE
Don't set nu and rnu, don't toggle unless &nu

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -2,10 +2,8 @@
 " Maintainer:        <https://jeffkreeftmeijer.com>
 " Version:           2.0.0
 
-set number relativenumber
-
 augroup numbertoggle
   autocmd!
-  autocmd BufEnter,FocusGained,InsertLeave * set relativenumber
-  autocmd BufLeave,FocusLost,InsertEnter   * set norelativenumber
+  autocmd BufEnter,FocusGained,InsertLeave * if &nu | set rnu   | endif
+  autocmd BufLeave,FocusLost,InsertEnter   * if &nu | set nornu | endif
 augroup END


### PR DESCRIPTION
Closes #19. Checks if `number` is enabled when before toggling
`relativenumber`, to disable numbertoggle automatically for buffers
without line numbers enabled (like the ones opened by Goyo and
NERDTree).

Please try it out (you'll have to set `number` and `relativenumber` yourself from this patch on), and let me know if it works with your plugins that open numberless buffers. ❤️