### PR TITLE
Add support for CmdlineEnter and CmdlineLeave events

### DIFF
--- a/autoload/number_toggle/toggle.vim
+++ b/autoload/number_toggle/toggle.vim
@@ -1,0 +1,13 @@
+
+function! number_toggle#toggle#Set_rnu()
+  if &nu
+    set rnu
+  endif
+endfunction
+
+function! number_toggle#toggle#Set_nornu()
+  if &nu
+    set nornu
+    redraw
+  endif
+endfunction

--- a/autoload/numbertoggle/toggle.vim
+++ b/autoload/numbertoggle/toggle.vim
@@ -1,11 +1,10 @@
-
-function! number_toggle#toggle#Set_rnu()
+function! numbertoggle#toggle#Set_rnu()
   if &nu
     set rnu
   endif
 endfunction
 
-function! number_toggle#toggle#Set_nornu()
+function! numbertoggle#toggle#Set_nornu()
   if &nu
     set nornu
     redraw

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -1,32 +1,21 @@
-" vim-numbertoggle - Automatic toggling between 'hybrid' and absolute line numbers
+" vim-number_toggle - Automatic toggling between 'hybrid' and absolute line numbers
 " Maintainer:        <https://jeffkreeftmeijer.com>
 " Version:           2.1.1
 
-augroup numbertoggle
+augroup number_toggle
   autocmd!
-  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * call Set_rnu()
-  autocmd BufLeave,FocusLost,InsertEnter,WinLeave  * call Set_nornu()
+  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * call number_toggle#toggle#Set_rnu()
+  autocmd BufLeave,FocusLost,InsertEnter,WinLeave  * call number_toggle#toggle#Set_nornu()
 
 
+  " CmdlineLeave and CmdlineEnter are new events. Older versions of 
+  " vim and nvim don't have them.
   if exists('##CmdlineLeave')
-    autocmd CmdlineLeave * call Set_rnu()
+    autocmd CmdlineLeave * call number_toggle#toggle#Set_rnu()
   endif
    
   if exists('##CmdlineEnter')
-    autocmd CmdlineEnter * call Set_nornu()
+    autocmd CmdlineEnter * call number_toggle#toggle#Set_nornu()
   endif
-
 augroup END
 
-function! Set_rnu()
-  if &nu
-    set rnu
-  endif
-endfunction
-
-function! Set_nornu()
-  if &nu
-    set nornu
-    redraw
-  endif
-endfunction

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -4,6 +4,6 @@
 
 augroup numbertoggle
   autocmd!
-  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
-  autocmd BufLeave,FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
+  autocmd BufEnter, CmdlineLeave, FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
+  autocmd BufLeave,CmdlineEnter, FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
 augroup END

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -5,5 +5,5 @@
 augroup numbertoggle
   autocmd!
   autocmd BufEnter, CmdlineLeave, FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
-  autocmd BufLeave,CmdlineEnter, FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
+  autocmd BufLeave, CmdlineEnter, FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
 augroup END

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -5,5 +5,5 @@
 augroup numbertoggle
   autocmd!
   autocmd BufEnter,CmdlineLeave,FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
-  autocmd BufLeave,CmdlineEnter,FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
+  autocmd BufLeave,CmdlineEnter,FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | redraw! | endif
 augroup END

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -1,21 +1,21 @@
-" vim-number_toggle - Automatic toggling between 'hybrid' and absolute line numbers
+" vim-numbertoggle - Automatic toggling between 'hybrid' and absolute line numbers
 " Maintainer:        <https://jeffkreeftmeijer.com>
 " Version:           2.1.1
 
-augroup number_toggle
+augroup numbertoggle
   autocmd!
-  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * call number_toggle#toggle#Set_rnu()
-  autocmd BufLeave,FocusLost,InsertEnter,WinLeave  * call number_toggle#toggle#Set_nornu()
+  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * call numbertoggle#toggle#Set_rnu()
+  autocmd BufLeave,FocusLost,InsertEnter,WinLeave  * call numbertoggle#toggle#Set_nornu()
 
 
   " CmdlineLeave and CmdlineEnter are new events. Older versions of 
   " vim and nvim don't have them.
   if exists('##CmdlineLeave')
-    autocmd CmdlineLeave * call number_toggle#toggle#Set_rnu()
+    autocmd CmdlineLeave * call numbertoggle#toggle#Set_rnu()
   endif
    
   if exists('##CmdlineEnter')
-    autocmd CmdlineEnter * call number_toggle#toggle#Set_nornu()
+    autocmd CmdlineEnter * call numbertoggle#toggle#Set_nornu()
   endif
 augroup END
 

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -13,9 +13,7 @@ augroup numbertoggle
   endif
    
   if exists('##CmdlineEnter')
-    call inputsave()
     autocmd CmdlineEnter * call Set_nornu()
-    call inputrestore()
   endif
 
 augroup END
@@ -29,6 +27,6 @@ endfunction
 function! Set_nornu()
   if &nu
     set nornu
-    " redraw!
+    redraw
   endif
 endfunction

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -4,6 +4,6 @@
 
 augroup numbertoggle
   autocmd!
-  autocmd BufEnter, CmdlineLeave, FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
-  autocmd BufLeave, CmdlineEnter, FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
+  autocmd BufEnter,CmdlineLeave,FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
+  autocmd BufLeave,CmdlineEnter,FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
 augroup END

--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -4,6 +4,31 @@
 
 augroup numbertoggle
   autocmd!
-  autocmd BufEnter,CmdlineLeave,FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
-  autocmd BufLeave,CmdlineEnter,FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | redraw! | endif
+  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * call Set_rnu()
+  autocmd BufLeave,FocusLost,InsertEnter,WinLeave  * call Set_nornu()
+
+
+  if exists('##CmdlineLeave')
+    autocmd CmdlineLeave * call Set_rnu()
+  endif
+   
+  if exists('##CmdlineEnter')
+    call inputsave()
+    autocmd CmdlineEnter * call Set_nornu()
+    call inputrestore()
+  endif
+
 augroup END
+
+function! Set_rnu()
+  if &nu
+    set rnu
+  endif
+endfunction
+
+function! Set_nornu()
+  if &nu
+    set nornu
+    " redraw!
+  endif
+endfunction


### PR DESCRIPTION
Vim and nvim have recently added the CmdlineEnter and CmdlineLeave events. This PR adds support for those events but only  if they are available. 

It think changing from relative numbers to nonrelative, when entering the command line, is useful for commands like 
```
:12,17t .
```
The changes in this PR are:
1. Add support for CmdlineEnter and CmdlineLeave events
2. The event handlers are moved to functions as to be as DRY as possible. Maybe there is a better pattern for that
3. `redraw!` is replaced by `redraw` because the former introduces a bug when used with said events. In case we enter command line with `/` or `?` initialy these characters disapear. `redraw` eliminates this.
4. The event handler make use of autoloader feature of vim 

