### PR TITLE
keep norelativenumbers on insert mode when focus re-gained 

### DIFF
--- a/plugin/number_toggle.vim
+++ b/plugin/number_toggle.vim
@@ -1,9 +1,9 @@
 " vim-numbertoggle - Automatic toggling between 'hybrid' and absolute line numbers
 " Maintainer:        <https://jeffkreeftmeijer.com>
-" Version:           2.1.1
+" Version:           2.1.2
 
 augroup numbertoggle
   autocmd!
-  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * if &nu | set rnu   | endif
+  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * if &nu && mode() != "i" | set rnu   | endif
   autocmd BufLeave,FocusLost,InsertEnter,WinLeave   * if &nu | set nornu | endif
 augroup END


### PR DESCRIPTION
When you are on insert mode and regain focus you end up with relative numbers on insert move, this change will avoid that issue.

when you are on insert mode numbers will be always norelative